### PR TITLE
[kbss-cvut/termit-ui#417] Extend popis dat ontology with term state

### DIFF
--- a/glosář.ttl
+++ b/glosář.ttl
@@ -953,3 +953,22 @@ a-popis-dat-pojem:má-datum-a-čas-vytvoření-verze
                 a-popis-dat:glosář ;
         <http://www.w3.org/2004/02/skos/core#prefLabel>
                 "Has date and time of version creation"@en , "Má datum a čas vytvoření verze"@cs .
+
+a-popis-dat-pojem:stav-pojmu
+        a       <http://www.w3.org/2004/02/skos/core#Concept> ;
+        <http://www.w3.org/2004/02/skos/core#broader>
+              a-popis-dat-pojem:term , <https://slovník.gov.cz/základní/pojem/typ-objektu> ;
+        <http://www.w3.org/2004/02/skos/core#inScheme>
+              a-popis-dat:glosář ;
+        <http://www.w3.org/2004/02/skos/core#prefLabel>
+              "State of term"@en , "Stav pojmu"@cs .
+
+a-popis-dat-pojem:má-stav-pojmu
+        a       <http://www.w3.org/2004/02/skos/core#Concept> ;
+        <http://www.w3.org/2004/02/skos/core#broader>
+                <https://slovník.gov.cz/základní/pojem/vztah> , <https://slovník.gov.cz/základní/pojem/typ-vztahu> ;
+        <http://www.w3.org/2004/02/skos/core#inScheme>
+                a-popis-dat:glosář ;
+        <http://www.w3.org/2004/02/skos/core#prefLabel>
+                "Has term state"@en , "Má stav pojmu"@cs .
+

--- a/model.ttl
+++ b/model.ttl
@@ -536,3 +536,13 @@ a-popis-dat-pojem:má-původní-hodnotu
         a                   <https://slovník.gov.cz/základní/pojem/typ-vztahu> ;
         rdfs:domain         a-popis-dat-pojem:úprava-entity ;
         rdfs:subPropertyOf  <https://slovník.gov.cz/základní/pojem/vztah> .
+
+a-popis-dat-pojem:stav-pojmu
+        a                   <https://slovník.gov.cz/základní/pojem/typ-objektu> , owl:Class ;
+        rdfs:subClassOf     a-popis-dat-pojem:term .
+
+a-popis-dat-pojem:má-stav-pojmu
+        a                   owl:ObjectProperty , <https://slovník.gov.cz/základní/pojem/typ-vztahu> ;
+        rdfs:domain         <http://www.w3.org/2004/02/skos/core#Concept> ;
+        rdfs:range          a-popis-dat-pojem:stav-pojmu .
+


### PR DESCRIPTION
Adds term state to the ontology to support implementation of kbss-cvut/termit-ui#417.

@MichalMed I was not sure `pdp:stav-pojmu` should be object type, but could not find anything better classifying the concept. I thought about Phase, but that requires a trope. Feel free to adjust.